### PR TITLE
Handle blank credentials in login

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ using Selenium.
 
 ## Usage
 
-Edit `apply_naukri.py` and fill in your login credentials and file paths. Then
-run the script:
+Edit `apply_naukri.py` and fill in your login credentials and file paths.
+If you leave the username and password blank, the script assumes you are already
+logged in using your browser. Then run the script:
 
 ```bash
 python apply_naukri.py

--- a/apply_naukri.py
+++ b/apply_naukri.py
@@ -41,6 +41,10 @@ def login(driver: webdriver.Chrome, creds: Credentials) -> None:
     driver.get('https://www.naukri.com/')
     time.sleep(2)
 
+    # If credentials are blank, assume the user is already logged in
+    if not creds.username and not creds.password:
+        return
+
     login_button = driver.find_element(By.LINK_TEXT, 'Login')
     login_button.click()
     time.sleep(2)


### PR DESCRIPTION
## Summary
- allow the login step to be skipped when both the username and password are blank
- document this behavior in the README

## Testing
- `python -m py_compile apply_naukri.py`


------
https://chatgpt.com/codex/tasks/task_e_68643b8d59a483319ec647f5561012ab