### PR TITLE
Read API key from env file and use job role list for search

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,14 @@ using Selenium.
    ```
 2. Download the appropriate WebDriver for your browser (e.g. `chromedriver`)
    and ensure it is available on your system `PATH`.
-3. Set your OpenAI API key in the `OPENAI_API_KEY` environment variable if you
-   want to generate cover letters (the script uses the `gpt-4o-mini` model but
-   does not generate letters by default).
+3. Create a `.env` file next to `apply_naukri.py` with your OpenAI key:
+
+   ```
+   OPENAI_API_KEY=your-key-here
+   ```
+   The script loads this file automatically if you want to generate cover
+   letters (it uses the `gpt-4o-mini` model but does not generate letters by
+   default).
 
 ## Usage
 

--- a/apply_naukri.py
+++ b/apply_naukri.py
@@ -5,10 +5,16 @@ import os
 import csv
 from datetime import datetime
 import json
+from pathlib import Path
 import openai
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file located next to this script
+load_dotenv(dotenv_path=Path(__file__).with_name('.env'))
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
+from typing import Iterable
 import time
 
 
@@ -60,11 +66,15 @@ def login(driver: webdriver.Chrome, creds: Credentials) -> None:
     time.sleep(5)
 
 
-def search_jobs(driver: webdriver.Chrome, query: str) -> None:
-    """Perform a job search with the given query."""
+def search_jobs(driver: webdriver.Chrome, queries: Iterable[str] | str) -> None:
+    """Perform a job search with the given job role queries."""
     search_box = driver.find_element(By.ID, 'qsb-keyword-sugg')
     search_box.clear()
-    search_box.send_keys(query)
+    if isinstance(queries, str):
+        query_text = queries
+    else:
+        query_text = " OR ".join(queries)
+    search_box.send_keys(query_text)
     search_box.send_keys(Keys.RETURN)
     time.sleep(3)
 
@@ -244,7 +254,7 @@ def main() -> None:
     driver = create_driver()
     try:
         login(driver, creds)
-        search_jobs(driver, 'Software Engineer')
+        search_jobs(driver, prefs.job_roles)
         apply_to_listings(driver, prefs)
     finally:
         driver.quit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 selenium>=4.0
 openai>=1.0
+python-dotenv>=1.0


### PR DESCRIPTION
## Summary
- load environment variables from `.env` using `python-dotenv`
- search for all job roles defined in `JobPreferences`
- update documentation to explain `.env` usage
- add `python-dotenv` to dependencies

## Testing
- `python -m py_compile apply_naukri.py`


------
https://chatgpt.com/codex/tasks/task_e_68643fa23df88331a9d68cd0e52eedaa